### PR TITLE
remove version line from compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,6 @@
-version: '3.8'
 services:
   postgres:
-    image: 'postgres:17.6-alpine3.21'
+    image: "postgres:17.6-alpine3.21"
     environment:
       POSTGRES_DB: recipe_app
       POSTGRES_USER: ${SPRING_DATASOURCE_USERNAME}
@@ -26,3 +25,4 @@ services:
 
 volumes:
   postgres_data:
+


### PR DESCRIPTION
It's deprecated, and docker keeps complaining about it. 

https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313